### PR TITLE
Fixed wrong URL & allow root for bower

### DIFF
--- a/btcp_store_demo.sh
+++ b/btcp_store_demo.sh
@@ -244,7 +244,7 @@ install_bower_browserify_js_libs() {
 
   # Build bitcore-lib-btcp.js + copy to invoice server's js/ dir
   cd ~/btcp-explorer/node_modules/store-demo
-  bower install
+  bower install --allow-root
   cd node_modules/bitcore-lib-btcp
   browserify --require ./index.js:bitcore-lib-btcp -o bitcore-lib-btcp.js
   cp bitcore-lib-btcp.js ~/btcp-explorer/node_modules/store-demo/static/js/bitcore-lib-btcp

--- a/btcp_store_demo.sh
+++ b/btcp_store_demo.sh
@@ -142,7 +142,7 @@ cd ~/BitcoinPrivate/src
 local RELEASE="1.0.12"
 local COMMIT="69aa9ce"
 local FILE="btcp-${RELEASE}-explorer-${COMMIT}-linux.tar.gz"
-wget -c https://github.com/BTCPrivate/BitcoinPrivate/releases/download/v${RELEASE}-${COMMIT}/${FILE}
+wget -c https://github.com/BTCPrivate/BitcoinPrivate/releases/download/${RELEASE}-${COMMIT}/${FILE}
 tar -zxvf $FILE
 echo "Downloading and extracting BTCP files - Done."
 rm -rf $FILE


### PR DESCRIPTION
Removed v from the BitcoinPrivate release URL which resulted in a wrong url.